### PR TITLE
Fixed typo.

### DIFF
--- a/modules/home-manager/desktop/services/impermanence.nix
+++ b/modules/home-manager/desktop/services/impermanence.nix
@@ -19,8 +19,8 @@ in {
 
   config = mkIf cfg.enable {
     # TODO rely on ephemeral BTRFS?
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/home-manager/options.nix
+++ b/modules/home-manager/options.nix
@@ -24,8 +24,8 @@ in {
     #   useGlobalPkgs = true;
     # };
 
-    # # any assertations that should be checked
-    # assertations = [
+    # # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/home-manager/shell/default.nix
+++ b/modules/home-manager/shell/default.nix
@@ -11,7 +11,7 @@ with lib.sylkos; let
 in {
   config = {
     assertions = [
-      # add some assertation about only having one shell enabled?
+      # add some assertion about only having one shell enabled?
       #{
       #  assertion = (countAttrs (n: v: n == "enable" && value) cfg) < 2;
       #  message = "Can't have more than one desktop environment enabled at a time";

--- a/modules/home-manager/shell/starship.nix
+++ b/modules/home-manager/shell/starship.nix
@@ -13,9 +13,9 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # TODO assertations here about zsh?
-    # any assertations that should be checked
-    # assertations = [
+    # TODO assertions here about zsh?
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/home-manager/themes/catppuccin.nix
+++ b/modules/home-manager/themes/catppuccin.nix
@@ -18,7 +18,7 @@ in {
   ];
 
   config = mkIf cfg.enabled {
-    #   # assertations = [
+    #   # assertions = [
     #   #   {
     #   #     assertion = true;
     #   #     message = "";

--- a/modules/nixos/audio.nix
+++ b/modules/nixos/audio.nix
@@ -14,8 +14,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/nixos/bluetooth.nix
+++ b/modules/nixos/bluetooth.nix
@@ -13,8 +13,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/nixos/monitors.nix
+++ b/modules/nixos/monitors.nix
@@ -58,8 +58,8 @@ in {
 
   config = mkIf (length cfg != 0) {
     # TODO Help?
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #       # assertion =
     # #           ((length cfg) != 0)
     # #           -> ((length (filter (m: m.primary) cfg)) == 1);

--- a/modules/nixos/network.nix
+++ b/modules/nixos/network.nix
@@ -14,8 +14,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/nixos/options.nix
+++ b/modules/nixos/options.nix
@@ -28,8 +28,8 @@ in {
   };
 
   config = {
-    # # any assertations that should be checked
-    # assertations = [
+    # # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/nixos/services/kdeconnect.nix
+++ b/modules/nixos/services/kdeconnect.nix
@@ -13,8 +13,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    #assertations = [
+    # any assertions that should be checked
+    #assertions = [
     #  {
     #    assertion = true;
     #    message = "";

--- a/modules/nixos/services/sops.nix
+++ b/modules/nixos/services/sops.nix
@@ -18,8 +18,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/modules/nixos/services/ssh.nix
+++ b/modules/nixos/services/ssh.nix
@@ -13,8 +13,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    # assertations = [
+    # any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";

--- a/tmp/templates/module.nix
+++ b/tmp/templates/module.nix
@@ -13,8 +13,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # any assertations that should be checked
-    assertations = [
+    # any assertions that should be checked
+    assertions = [
       {
         assertion = true;
         message = "";

--- a/users/default.nix
+++ b/users/default.nix
@@ -94,8 +94,8 @@ in {
         cfg);
     };
 
-    #   any assertations that should be checked
-    # assertations = [
+    #   any assertions that should be checked
+    # assertions = [
     #   {
     #     assertion = true;
     #     message = "";


### PR DESCRIPTION
Fixed with the same method as the previous PR. As before, since this preserves the meaning of the option, no further changes are needed.